### PR TITLE
Handle shell expansion of glob patterns 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. 
+
+This file was created recently as I didn't document previous changes correctly. I'll try to backport stuff and as I do I'll remove this warning, but in the meantime I'm keeping this for context.
+Also, this process is new to me in terms of taking charge of writting it so I'll make all the necessary newbie mistakes, don't bear with me, point them out!
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [0.0.8.0] - 2019-02-17
+### Added
+- `CHANGELOG` file
+### Changed
+- `copy` command now takes paths as an array, this allows for proper handling of shell expansion of a glob pattern [@dramalho](https://github.com/dramalho).
+

--- a/lib/media_archiver/version.rb
+++ b/lib/media_archiver/version.rb
@@ -1,3 +1,3 @@
 module MediaArchiver
-  VERSION = "0.0.7.4"
+  VERSION = '0.0.8.0'.freeze
 end

--- a/media_archiver.gemspec
+++ b/media_archiver.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1'
-  spec.add_development_dependency 'rake', '~> 11'
   spec.add_development_dependency 'byebug', '~> 9'
+  spec.add_development_dependency 'rake', '~> 11'
 
-  spec.add_dependency 'mini_exiftool', '~> 2.7'
+  spec.add_dependency 'mini_exiftool', '~> 2.9'
   spec.add_dependency 'thor', '~> 0'
 end


### PR DESCRIPTION
This allows the use of wilcards when defining which folders to copy. Your operating system shell will - most likely - expand the pattern and provide a list of folders which the previous signature of the `copy` command wouldn't allow. 

This fixes it!